### PR TITLE
Update jquery.metacookie.js to allow passing of extra params to $.setMetaCookie

### DIFF
--- a/jquery.metacookie.js
+++ b/jquery.metacookie.js
@@ -152,7 +152,7 @@ jQuery.extend(true, ( function () {
    * @param {String} value The value to set
    * @return {Void}
    */  
-  function setMetaCookie(subName, name, value) {
+  function setMetaCookie(subName, name, value, expires, path, domain, secure) {
     var currentCookieVal = getCookie(name),
     subCookies = [],
     temp = [],
@@ -188,7 +188,7 @@ jQuery.extend(true, ( function () {
         }
       }
 	  }
-    return(setCookie(name, newCookieVal));
+    return(setCookie(name, newCookieVal, expires, path, domain, secure));
   }
 
   /**


### PR DESCRIPTION
Pass extra params to $.setMetaCookie, which can then be passed to $.setCookie (where these extra params already exist). Probably better would be to change the signature to pass one config object, but I don't want to mess up the existing API.
